### PR TITLE
Use this.results to avoid collisions with module built-ins

### DIFF
--- a/MMM-YNAB.js
+++ b/MMM-YNAB.js
@@ -1,20 +1,21 @@
 Module.register("MMM-YNAB", {
+    result: [],
     defaults: {
         token: "",
         categories: [ "Household", "Pets", "Grocery", "Lunch", "Kids Clothes", "Restaurants", "Spontaneous Fun" ]
     },
 
     start: function () {
-        this.sendSocketNotification('SET_CONFIG', this.config);
+        this.sendSocketNotification('YNAB_SET_CONFIG', this.config);
     },
 
     getDom: function () {
         var wrapper = document.createElement("div");
         wrapper.classList = ["xsmall"];
-	console.log('Data length: ' + this.data.items.length);
-        if (this.data.items && this.data.items.length > 0) {
-	    for (let i of this.data.items) {
-                wrapper.innerHTML = this.data.items.map(a => "<span class='ynab-name'>" + a.name + "</span><span class='ynab-balance'>$" + (a.balance/1000).toFixed(2) + "</span>").join('');
+        wrapper.innerHTML = "Loading YNAB";
+        if (this.result.items && this.result.items.length > 0) {
+            for (let i of this.result.items) {
+                wrapper.innerHTML = this.result.items.map(a => "<span class='ynab-name'>" + a.name + "</span><span class='ynab-balance'>$" + (a.balance/1000).toFixed(2) + "</span>").join('');
             }
         }
         return wrapper;
@@ -22,13 +23,13 @@ Module.register("MMM-YNAB", {
 
     socketNotificationReceived: function (notification, payload) {
         console.log("notification: " + notification);
-        console.log("payload: " + payload);
-        if (notification == "UPDATE") {
-            this.data = payload;
+        console.log("payload: " + JSON.stringify(payload));
+        if (notification == "YNAB_UPDATE") {
+            this.result = payload;
             this.updateDom(0);
         }
     },
-    
+
     getStyles: function() {
         return [
             this.file('MMM-YNAB.css')

--- a/node_helper.js
+++ b/node_helper.js
@@ -8,21 +8,16 @@ var interval;
 module.exports = NodeHelper.create({
 
 	socketNotificationReceived: function (noti, payload) {
-		console.log("Notification received: " + noti);
-		if (noti == "SET_CONFIG") {
+		if (noti == "YNAB_SET_CONFIG") {
 			this.initialize(payload);
 		}
 	},
 
 	initialize: function (payload) {
-		console.log("initialize");
 		config = payload;
 		var ynabAPI = new ynab.API(config.token);
 
-		console.log("created api");
-
 		ynabAPI.budgets.getBudgets().then(budgetsResponse => {
-			console.log("budgetsResponse: " + JSON.stringify(budgetsResponse));
 			ynabBudgetId = budgetsResponse.data.budgets[0].id;
 			this.updateBudget();
 			if (!interval) {
@@ -35,18 +30,13 @@ module.exports = NodeHelper.create({
 	},
 
 	updateBudget: function () {
-		console.log("updateBudget: " + ynabBudgetId);
 		var ynabAPI = new ynab.API(config.token);
-		console.log("created api");
 		ynabAPI.categories.getCategories(ynabBudgetId).then(categoriesResponse => {
-			console.log("got cats");
 			const map = [].concat(...Array.from(categoriesResponse.data.category_groups.map(a => Array.from(a.categories)))).reduce((map, o) => { map[o.name] = o; return map; }, new Map());
 			var list = config.categories.map(a => map[a]).filter(a => a != undefined);
-			console.log("list: " + JSON.stringify(list));
-			self.sendSocketNotification("UPDATE", {
+			self.sendSocketNotification("YNAB_UPDATE", {
 				items: list,
 			});
-			console.log("sent update");
 		}).catch(e => {
 			console.log("error: " + e);
 		});


### PR DESCRIPTION
Main fix is to use `this.result` instead of `this.data` to avoid collisions with module internals. I've included a few QOL improvements but happy to remove them if you disagree. 

* Add an initial `result` of an empty list to remove existence checks
* Add a Loading YNAB initial message if data is not yet available
* Rename socket notifications to be prefixed with YNAB to prevent collisions with other modules
* Standardize on spaces and remove mixed-in tabs
* Removed debug logging that looked like it was added for debugging this issue


Fixes #1 